### PR TITLE
Allow undescore character in Uri host

### DIFF
--- a/src/Message/Uri.php
+++ b/src/Message/Uri.php
@@ -55,7 +55,7 @@ final class Uri implements UriInterface
         }
         // @codeCoverageIgnoreEnd
 
-        if ($parts === false || (isset($parts['scheme']) && !\preg_match('#^[a-z]+$#i', $parts['scheme'])) || (isset($parts['host']) && \preg_match('#[\s_%+]#', $parts['host']))) {
+        if ($parts === false || (isset($parts['scheme']) && !\preg_match('#^[a-z]+$#i', $parts['scheme'])) || (isset($parts['host']) && \preg_match('#[\s%+]#', $parts['host']))) {
             throw new \InvalidArgumentException('Invalid URI given');
         }
 
@@ -173,7 +173,7 @@ final class Uri implements UriInterface
             return $this;
         }
 
-        if (\preg_match('#[\s_%+]#', $host) || ($host !== '' && \parse_url('http://' . $host, \PHP_URL_HOST) !== $host)) {
+        if (\preg_match('#[\s%+]#', $host) || ($host !== '' && \parse_url('http://' . $host, \PHP_URL_HOST) !== $host)) {
             throw new \InvalidArgumentException('Invalid URI host given');
         }
 


### PR DESCRIPTION
I don't understand why this validity check has be added. Has per rfc 2181 (https://datatracker.ietf.org/doc/html/rfc2181#section-11), underscore are valid character to use in an uri host.

For my specific usage, it broke for requests using docker internal hostnames.